### PR TITLE
Fix character shadows only showing one big quarter of the shadow.

### DIFF
--- a/bin/segment2.c
+++ b/bin/segment2.c
@@ -2559,7 +2559,7 @@ const Gfx dl_shadow_begin[] = {
 
 const Gfx dl_shadow_circle[] = {
     gsSPDisplayList(dl_shadow_begin),
-    gsDPLoadTextureBlock(texture_shadow_quarter_circle, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, 0, G_TX_WRAP | G_TX_MIRROR, G_TX_WRAP | G_TX_MIRROR, 4, 4, G_TX_NOLOD, G_TX_NOLOD),
+    gsDPLoadTextureBlock(texture_shadow_quarter_circle, G_IM_FMT_IA, G_IM_SIZ_8b, 16, 16, 0, G_TX_CLAMP | G_TX_CLAMP, G_TX_CLAMP | G_TX_CLAMP, 4, 4, G_TX_NOLOD, G_TX_NOLOD),
     gsSPEndDisplayList(),
 };
 

--- a/src/game/shadow.c
+++ b/src/game/shadow.c
@@ -259,25 +259,37 @@ s8 init_shadow(struct Shadow *s, f32 xPos, f32 yPos, f32 zPos, s16 shadowScale, 
 
 /**
  * Given a `vertexNum` from a shadow with nine vertices, update the
- * texture coordinates corresponding to that vertex. That is:
- *      0 = (0,   0)         1 = (7,   0)         2 = (15,   0)
- *      3 = (0,   7)         4 = (7,   7)         5 = (15,   7)
- *      6 = (0,  15)         7 = (7,  15)         8 = (15,  15)
+ * texture coordinates corresponding to that vertex. For quarter-circle
+ * textures (16x16), this maps the full mirrored range to 32 texels:
+ *      0 = (0,   0)         1 = (15,   0)         2 = (31,   0)
+ *      3 = (0,  15)         4 = (15,  15)         5 = (31,  15)
+ *      6 = (0,  31)         7 = (15,  31)         8 = (31,  31)
  */
 void get_texture_coords_9_vertices(s8 vertexNum, s16 *textureX, s16 *textureY) {
-    *textureX = (vertexNum % 3) * 8 - !((vertexNum % 3) == 0);
-    *textureY = (vertexNum / 3) * 8 - !((vertexNum / 3) == 0);
+#if defined(TARGET_PSP)
+    // 180-degree quadrant flips for PSP when G_TX_MIRROR is missing.
+    // Convert nominal 0/15/31 coordinates to anti-mirror: 15/0/15.
+    s16 baseX = (vertexNum % 3) * 16 - !((vertexNum % 3) == 0);
+    s16 baseY = (vertexNum / 3) * 16 - !((vertexNum / 3) == 0);
+
+    *textureX = (baseX <= 15) ? (15 - baseX) : (baseX - 16);
+    *textureY = (baseY <= 15) ? (15 - baseY) : (baseY - 16);
+#else
+    *textureX = (vertexNum % 3) * 16 - !((vertexNum % 3) == 0);
+    *textureY = (vertexNum / 3) * 16 - !((vertexNum / 3) == 0);
+#endif
 }
 
 /**
  * Given a `vertexNum` from a shadow with four vertices, update the
- * texture coordinates corresponding to that vertex. That is:
- *      0 = (0,   0)         1 = (15,   0)
- *      2 = (0,  15)         3 = (15,  15)
+ * texture coordinates corresponding to that vertex. For quarter-circle
+ * textures, this maps to the full mirrored range:
+ *      0 = (0,   0)         1 = (31,   0)
+ *      2 = (0,  31)         3 = (31,  31)
  */
 void get_texture_coords_4_vertices(s8 vertexNum, s16 *textureX, s16 *textureY) {
-    *textureX = (vertexNum % 2) * 15;
-    *textureY = (vertexNum / 2) * 15;
+    *textureX = (vertexNum % 2) * 31;
+    *textureY = (vertexNum / 2) * 31;
 }
 
 /**
@@ -672,6 +684,12 @@ Gfx *create_shadow_circle_9_verts(f32 xPos, f32 yPos, f32 zPos, s16 shadowScale,
  * Create a circular shadow composed of 4 vertices.
  */
 Gfx *create_shadow_circle_4_verts(f32 xPos, f32 yPos, f32 zPos, s16 shadowScale, u8 solidity) {
+#if defined(TARGET_PSP)
+    // PSP does not support hardware mirrored texture wrapping. Use the
+    // 9-vertex shadow path (with mirror-emulated UVs) so the circle is
+    // composed correctly.
+    return create_shadow_circle_9_verts(xPos, yPos, zPos, shadowScale, solidity);
+#else
     Vtx *verts;
     Gfx *displayList;
     struct Shadow shadow;
@@ -693,6 +711,7 @@ Gfx *create_shadow_circle_4_verts(f32 xPos, f32 yPos, f32 zPos, s16 shadowScale,
     }
     add_shadow_to_display_list(displayList, verts, SHADOW_WITH_4_VERTS, SHADOW_SHAPE_CIRCLE);
     return displayList;
+#endif
 }
 
 /**

--- a/src/pc/gfx/gfx_opengl_legacy.c
+++ b/src/pc/gfx/gfx_opengl_legacy.c
@@ -559,12 +559,8 @@ static uint32_t gfx_cm_to_opengl(uint32_t val) {
     if (val & G_TX_CLAMP)
         return GL_CLAMP_TO_EDGE;
 #if defined(TARGET_PSP)
-    /*@Note: no mirroring on pspgl, still unsure how to properly handle
-        for now, directly patching the images and DLs to fix */
-    /*if(val & G_TX_MIRROR){
-        glDisable(GL_TEXTURE_2D);
-    }*/
-    return GL_REPEAT;//(val & G_TX_MIRROR) ? GL_REPEAT : GL_REPEAT;
+    /*@Note: try GL_MIRRORED_REPEAT on pspgl */
+    return (val & G_TX_MIRROR) ? GL_MIRRORED_REPEAT : GL_REPEAT;
 #else
     return (val & G_TX_MIRROR) ? GL_MIRRORED_REPEAT : GL_REPEAT;
 #endif


### PR DESCRIPTION
Now character shadows are a full circle under the character. This fixes issue #30.

Instead of using G_TX_WRAP and then mirroring each of the three repeating quarters (which we can't do as PSPGL does not support mirroring) we just clamp each quarter to it's tile and manually mirror/rotate each one to point in the right direction.