### PR TITLE
cannon, transitions, fog

### DIFF
--- a/actors/explosion/model.inc.c
+++ b/actors/explosion/model.inc.c
@@ -45,7 +45,7 @@ ALIGNED8 static const u8 explosion_seg3_texture_03003A08[] = {
 
 // 0x03004208 - 0x03004298
 const Gfx explosion_seg3_dl_03004208[] = {
-    gsDPSetCombineMode(G_CC_DECALFADEA, G_CC_DECALFADEA),
+    gsDPSetCombineMode(G_CC_BLENDRGBA, G_CC_BLENDRGBA),
     gsDPSetEnvColor(255, 255, 255, 150),
     gsSPClearGeometryMode(G_LIGHTING),
     gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),

--- a/levels/hmc/areas/1/9/model.inc.c
+++ b/levels/hmc/areas/1/9/model.inc.c
@@ -96,7 +96,7 @@ static const Gfx hmc_seg7_dl_0700FDF0[] = {
 const Gfx hmc_seg7_dl_0700FEF0[] = {
     gsDPPipeSync(),
     gsDPSetEnvColor(255, 255, 255, 128),
-    gsDPSetCombineMode(G_CC_DECALFADEA, G_CC_DECALFADEA),
+    gsDPSetCombineMode(G_CC_BLENDRGBA, G_CC_BLENDRGBA),
     gsSPClearGeometryMode(G_LIGHTING | G_CULL_BACK),
     gsDPSetTile(G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, 0, G_TX_LOADTILE, 0, G_TX_WRAP | G_TX_NOMIRROR, G_TX_NOMASK, G_TX_NOLOD, G_TX_WRAP | G_TX_NOMIRROR, G_TX_NOMASK, G_TX_NOLOD),
     gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),

--- a/src/game/screen_transition.c
+++ b/src/game/screen_transition.c
@@ -182,7 +182,9 @@ s32 render_textured_transition(s8 fadeTimer, s8 transTime, struct WarpTransition
         gSPVertex(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(verts), 8, 0);
         gSPDisplayList(gDisplayListHead++, dl_transition_draw_filled_region);
         gDPPipeSync(gDisplayListHead++);
-        gDPSetCombineMode(gDisplayListHead++, G_CC_MODULATEIDECALA, G_CC_MODULATEIDECALA);
+        //gDPSetCombineMode(gDisplayListHead++, G_CC_MODULATEIDECALA, G_CC_MODULATEIDECALA);
+        gDPSetPrimColor(gDisplayListHead++, 0, 0, transData->red, transData->green, transData->blue, 255);
+        gDPSetCombineMode(gDisplayListHead++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
         gDPSetRenderMode(gDisplayListHead++, G_RM_AA_XLU_SURF, G_RM_AA_XLU_SURF2);
         gDPSetTextureFilter(gDisplayListHead++, G_TF_BILERP);
         switch (transTexType) {
@@ -266,7 +268,8 @@ Gfx *render_cannon_circle_base(void) {
 #endif
 
         gSPDisplayList(g++, dl_proj_mtx_fullscreen);
-        gDPSetCombineMode(g++, G_CC_MODULATEIDECALA, G_CC_MODULATEIDECALA);
+        //gDPSetCombineMode(g++, G_CC_MODULATEIDECALA, G_CC_MODULATEIDECALA);
+        gDPSetCombineMode(gDisplayListHead++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
         gDPSetTextureFilter(g++, G_TF_BILERP);
         gDPLoadTextureBlock(g++, sTextureTransitionID[TEX_TRANS_CIRCLE], G_IM_FMT_IA, G_IM_SIZ_8b, 32, 64, 0,
             G_TX_WRAP | G_TX_MIRROR, G_TX_WRAP | G_TX_MIRROR, 5, 6, G_TX_NOLOD, G_TX_NOLOD);

--- a/src/pc/gfx/gfx_scegu.c
+++ b/src/pc/gfx/gfx_scegu.c
@@ -333,15 +333,16 @@ static void gfx_scegu_apply_shader(struct ShaderProgram *prg) {
         sceGuDisable(GU_TEXTURE_2D);
         return;
     }
-/*@Note: Revisit one day! */
-#if 0
+
     if (prg->shader_id & SHADER_OPT_FOG) {
-        // Yea this doesnt work at all */
-        //sceGuFog(scegu_fog_near, scegu_fog_far, 0x00FF0000);//scegu_fog_color); // color is the same for all verts, only intensity is different
-        //sceGuEnable(GU_FOG);
-        sceGuEnable(GU_BLEND);
+        sceGuEnable(GU_FOG);
+
+        // Set fog parameters
+        //sceGuFog(1.0f, 10.0f, scegu_fog_color);
+        sceGuFog(3600.0f, 32000.0f, 0xFFFFFFFF);
+    } else {
+        sceGuDisable(GU_FOG);
     }
-#endif
 
     if (prg->num_inputs) {
         // have colors


### PR DESCRIPTION
cannon overlay is now black
screen transitions are now the correct color
fog works (at least in bob omb battlefield it looks nice)